### PR TITLE
ANN-SoLo as Python API

### DIFF
--- a/src/ann_solo/__init__.py
+++ b/src/ann_solo/__init__.py
@@ -1,4 +1,6 @@
 __version__ = '0.2.4'
 
+from .ann_solo import ann_solo
+
 __all__ = ['ann_solo', 'config', 'plot_ssm', 'reader', 'spectral_library',
            'spectrum', 'spectrum_match', 'utils', 'writer']

--- a/src/ann_solo/__init__.py
+++ b/src/ann_solo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 from .ann_solo import ann_solo
 

--- a/src/ann_solo/ann_solo.py
+++ b/src/ann_solo/ann_solo.py
@@ -27,24 +27,28 @@ def ann_solo(spectral_library_filename: str, query_filename: str,
         https://github.com/bittremieux/ANN-SoLo/wiki/Parameters). Values
         MUST be the argument values. Boolean flags can be toggled by
         specifying True or False (ex: no_gpu=True).
+
+    Returns
+    -------
+    str
+        The file name of the mzTab output file.
     """
     # Convert kwargs dictionary to list for main().
     # 'args' contains arguments with values.
     # 'flags' contains boolean flags to include
     args = sum([['--' + k, str(v)] for k, v in kwargs.items()
                 if not isinstance(v, bool)], [])
-
     flags = ['--' + k for k, v in kwargs.items() if v and isinstance(v, bool)]
 
     # Explicitly set the search parameters when run from Python.
-    main([spectral_library_filename, query_filename, out_filename, *args,
-          *flags])
+    out_filename = main([spectral_library_filename, query_filename,
+                         out_filename, *args, *flags])
 
     # Return the mzTab output file name.
     return out_filename
 
 
-def main(args: Union[str, List[str]] = None):
+def main(args: Union[str, List[str]] = None) -> str:
     # Initialize logging.
     logging.basicConfig(format='{asctime} [{levelname}/{processName}] '
                                '{module}.{funcName} : {message}',
@@ -57,11 +61,13 @@ def main(args: Union[str, List[str]] = None):
     spec_lib = spectral_library.SpectralLibrary(
         config.spectral_library_filename)
     identifications = spec_lib.search(config.query_filename)
-    writer.write_mztab(identifications, config.out_filename,
-                       spec_lib._library_reader)
+    out_filename = writer.write_mztab(identifications, config.out_filename,
+                                      spec_lib._library_reader)
     spec_lib.shutdown()
 
     logging.shutdown()
+
+    return out_filename
 
 
 if __name__ == '__main__':

--- a/src/ann_solo/ann_solo.py
+++ b/src/ann_solo/ann_solo.py
@@ -1,18 +1,44 @@
 import logging
+from typing import List, Union
 
 from ann_solo import spectral_library
 from ann_solo import writer
 from ann_solo.config import config
 
 
-def main():
+def ann_solo(spectral_library_filename: str, query_filename: str,
+             out_filename: str, args: List[str]) -> None:
+    """
+    Run ANN-SoLo.
+
+    The identified PSMs will be stored in the given file.
+
+    Parameters
+    ----------
+    spectral_library_filename : str
+        The spectral library file name.
+    query_filename : str
+        The query spectra file name.
+    out_filename : str
+        The mzTab output file name.
+    args : List[str]
+        List of additional search settings. List items either MUST match the
+        commandline arguments (including '--' prefix;
+        https://github.com/bittremieux/ANN-SoLo/wiki/Parameters) or MUST be
+        values as strings.
+    """
+    # Explicitly set the search parameters when run from Python.
+    main([spectral_library_filename, query_filename, out_filename, *args])
+
+
+def main(args: Union[str, list] = None):
     # Initialize logging.
     logging.basicConfig(format='{asctime} [{levelname}/{processName}] '
                                '{module}.{funcName} : {message}',
                         style='{', level=logging.DEBUG)
 
     # Load the configuration.
-    config.parse()
+    config.parse(args)
 
     # Perform the search.
     spec_lib = spectral_library.SpectralLibrary(
@@ -26,4 +52,5 @@ def main():
 
 
 if __name__ == '__main__':
+    # Use search parameters from sys.argv when run from CMD.
     main()

--- a/src/ann_solo/ann_solo.py
+++ b/src/ann_solo/ann_solo.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Dict, Optional
+from typing import List, Union
 
 from ann_solo import spectral_library
 from ann_solo import writer
@@ -7,9 +7,12 @@ from ann_solo.config import config
 
 
 def ann_solo(spectral_library_filename: str, query_filename: str,
-             out_filename: str, **kwargs) -> str:
+             out_filename: str, **kwargs: Union[bool, float, int, str]) -> str:
     """
-    Run ANN-SoLo.
+    Run ANN-SoLo with the specified search settings.
+
+    Values for search settings that are not explicitly specified will be taken
+    from the config file (if present) or take their default values.
 
     The identified PSMs will be stored in the given file.
 
@@ -21,7 +24,7 @@ def ann_solo(spectral_library_filename: str, query_filename: str,
         The query spectra file name.
     out_filename : str
         The mzTab output file name.
-    **kwargs
+    **kwargs : Union[bool, float, int, str]
         Additional search settings. Keys MUST match the command line
         arguments (excluding the '--' prefix;
         https://github.com/bittremieux/ANN-SoLo/wiki/Parameters). Values

--- a/src/ann_solo/ann_solo.py
+++ b/src/ann_solo/ann_solo.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union
+from typing import List, Union, Dict, Optional
 
 from ann_solo import spectral_library
 from ann_solo import writer
@@ -7,7 +7,7 @@ from ann_solo.config import config
 
 
 def ann_solo(spectral_library_filename: str, query_filename: str,
-             out_filename: str, args: List[str]) -> None:
+             out_filename: str, **kwargs) -> str:
     """
     Run ANN-SoLo.
 
@@ -21,14 +21,27 @@ def ann_solo(spectral_library_filename: str, query_filename: str,
         The query spectra file name.
     out_filename : str
         The mzTab output file name.
-    args : List[str]
-        List of additional search settings. List items either MUST match the
-        commandline arguments (including '--' prefix;
-        https://github.com/bittremieux/ANN-SoLo/wiki/Parameters) or MUST be
-        values as strings.
+    **kwargs
+        Additional search settings. Keys MUST match the command line
+        arguments (excluding the '--' prefix;
+        https://github.com/bittremieux/ANN-SoLo/wiki/Parameters). Values
+        MUST be the argument values. Boolean flags can be toggled by
+        specifying True or False (ex: no_gpu=True).
     """
+    # Convert kwargs dictionary to list for main().
+    # 'args' contains arguments with values.
+    # 'flags' contains boolean flags to include
+    args = sum([['--' + k, str(v)] for k, v in kwargs.items()
+                if not isinstance(v, bool)], [])
+
+    flags = ['--' + k for k, v in kwargs.items() if v and isinstance(v, bool)]
+
     # Explicitly set the search parameters when run from Python.
-    main([spectral_library_filename, query_filename, out_filename, *args])
+    main([spectral_library_filename, query_filename, out_filename, *args,
+          *flags])
+
+    # Return the mzTab output file name.
+    return out_filename
 
 
 def main(args: Union[str, List[str]] = None):

--- a/src/ann_solo/ann_solo.py
+++ b/src/ann_solo/ann_solo.py
@@ -31,7 +31,7 @@ def ann_solo(spectral_library_filename: str, query_filename: str,
     main([spectral_library_filename, query_filename, out_filename, *args])
 
 
-def main(args: Union[str, list] = None):
+def main(args: Union[str, List[str]] = None):
     # Initialize logging.
     logging.basicConfig(format='{asctime} [{levelname}/{processName}] '
                                '{module}.{funcName} : {message}',

--- a/src/ann_solo/writer.py
+++ b/src/ann_solo/writer.py
@@ -38,7 +38,7 @@ def natural_sort_key(s: str, _nsre: Pattern[AnyStr] = re.compile('([0-9]+)'))\
 
 
 def write_mztab(identifications: List[SpectrumSpectrumMatch], filename: str,
-                lib_reader: SpectralLibraryReader) -> None:
+                lib_reader: SpectralLibraryReader) -> str:
     """
     Write the given SSMs to an mzTab file.
 
@@ -51,6 +51,11 @@ def write_mztab(identifications: List[SpectrumSpectrumMatch], filename: str,
         '.mztab' extension this will be added.
     lib_reader : SpectralLibraryReader
         The spectral library reader used during identifications.
+
+    Returns
+    -------
+    str
+        The file name of the mzTab output file.
     """
     # Check if the filename contains the mztab extension and add if required.
     if os.path.splitext(filename)[1].lower() != '.mztab':
@@ -142,3 +147,5 @@ def write_mztab(identifications: List[SpectrumSpectrumMatch], filename: str,
                 'null', 'null', 'null', 'null',
                 f'{ssm.is_decoy:d}',
                 str(ssm.num_candidates)]) + '\n')
+
+    return filename


### PR DESCRIPTION
Required arguments for the Python API are the positional command-line arguments. Optional command-line arguments can be specified and must exactly match the CMD arguments (including '--' prefix) while the values must be strings.

Example usage:
```
from ann_solo import ann_solo


ann_solo.ann_solo('human_yeast_targetdecoy.splib',
                  'iPRG2012.mgf',
                  'iPRG2012.mztab',
                  ['--precursor_tolerance_mass', '20',
                   '--precursor_tolerance_mode', 'ppm',
                   '--fragment_mz_tolerance', '0.02',
                   '--remove_precursor'])
```